### PR TITLE
Updated delete in syncMailingList and sync assignApplicationStatus (#…

### DIFF
--- a/src/controller/applicationStatus/assignApplicationStatus.ts
+++ b/src/controller/applicationStatus/assignApplicationStatus.ts
@@ -180,7 +180,8 @@ export default async (legit?: boolean, waitlistOver?: boolean, rawAcceptedFromWa
     }
   }
 
+  
   await syncMailingLists(undefined, true);
-
+  
   return { dead, accepted, rejected, waitlisted };
 };

--- a/src/services/mailer/syncMailingList.ts
+++ b/src/services/mailer/syncMailingList.ts
@@ -60,12 +60,13 @@ export default async (mailingListID: string, emails: string[], forceUpdate?: boo
   // Step 3: Delete users that are on the list that shouldn't be
   const toBeDeleted = [...beforeSubscribers].filter(x => !expctedAfterSubscribers.has(x) && x);
 
-  const deleteOldResults = await Promise.all(toBeDeleted.map(
+  const deleteOldResults = await Promise.allSettled(toBeDeleted.map(
     (userEmail: string) => deleteSubscriptionRequest(mailingListID, userEmail),
   ));
 
   for (const result of deleteOldResults) {
-    if (result.status != 200 || !result.data) {
+    if ((result.status === 'fulfilled' && !result.value) 
+      || (result.status === 'rejected' && result.reason != 'failed to fetch') ) {
       throw new InternalServerError('Unable to delete subscriber');
     }
   }


### PR DESCRIPTION
…139)

* Updated delete in syncMailingList and sync assignApplicationStatus

- delete Promise.all was changed to Promise.allSettled
- if user is not found, an error is not thrown
- only syncing the mailing list if legit is true

* Fixed delete error logic

* Removed legit